### PR TITLE
Mark Free monad implementation as covering

### DIFF
--- a/src/Control/Monad/Free.idr
+++ b/src/Control/Monad/Free.idr
@@ -23,7 +23,7 @@ Syntax sig => Applicative (Free sig) where
   Return v <*> prog = map v prog
   Op op    <*> prog = Op (emap (<*> prog) op)
 
-public export
+public export covering
 Syntax sig => Monad (Free sig) where
   Return v >>= prog = prog v
   Op op    >>= prog = Op (emap (>>= prog) op)


### PR DESCRIPTION
Prelude's Monad interface is now total by default.